### PR TITLE
Introducing Except attribute 

### DIFF
--- a/lib/action_bouncer/allowance.rb
+++ b/lib/action_bouncer/allowance.rb
@@ -6,9 +6,10 @@ module ActionBouncer
       @resource_sym, @options = resource_sym, options
     end
 
-    def not_allowed?(controller, action)
+    def allowed?(controller, action)
       resource = controller.send(@resource_sym)
-      !allowed_action?(action) || !matches_resource_condition?(resource)
+      allowed_action?(action) &&
+       matches_resource_condition?(resource)
     end
 
     private

--- a/lib/action_bouncer/allowance.rb
+++ b/lib/action_bouncer/allowance.rb
@@ -8,8 +8,8 @@ module ActionBouncer
 
     def allowed?(controller, action)
       resource = controller.send(@resource_sym)
-      allowed_action?(action) &&
-       matches_resource_condition?(resource)
+      exception_action?(action) ||
+        (allowed_action?(action) && matches_resource_condition?(resource))
     end
 
     private
@@ -18,12 +18,20 @@ module ActionBouncer
       allowed_actions.include?(action.to_sym) || allowed_actions.include?(:all)
     end
 
+    def exception_action?(action)
+      exception_actions.include?(action.to_sym)
+    end
+
     def matches_resource_condition?(resource)
       conditions.any? { |condition| resource.send(condition).present? }
     end
 
     def allowed_actions
       Array.wrap(@options[:to])
+    end
+
+    def exception_actions
+      Array.wrap(@options[:except])
     end
 
     def conditions

--- a/lib/action_bouncer/authorization.rb
+++ b/lib/action_bouncer/authorization.rb
@@ -8,14 +8,14 @@ module ActionBouncer
 
     def authorize!(controller)
       return if @allowances.nil?
-      fail Unauthorized if unauthorized?(controller)
+      fail Unauthorized unless authorized?(controller)
     end
 
     private
 
-    def unauthorized?(controller)
+    def authorized?(controller)
       action = controller.send(:params).fetch(:action)
-      @allowances.all? { |allowance| allowance.not_allowed?(controller, action) }
+      @allowances.any? { |allowance| allowance.allowed?(controller, action) }
     end
   end
 end

--- a/spec/controllers/except_param_controller_spec.rb
+++ b/spec/controllers/except_param_controller_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+
+class ExceptParamController < ActionController::Base
+  helper_method :current_user
+
+  include ActionBouncer
+
+  allow :current_user,
+    to: [:index, :new],
+    except: :edit,
+    if: :admin?
+
+  def index
+    render nothing: true, status: :success
+  end
+
+  def new
+    render nothing: true, status: :success
+  end
+
+  def edit
+    render nothing: true, status: :success
+  end
+end
+
+describe ExceptParamController do
+  before do
+    Rails.application.routes.draw do
+      get '/index' => 'except_param#index'
+      get '/new' => 'except_param#new'
+      get '/edit' => 'except_param#edit'
+    end
+  end
+
+  context 'when authorized' do
+    before do
+      allow(subject).to receive(:current_user) { OpenStruct.new(admin?: true) }
+    end
+
+    it { expect{ get :edit }.not_to raise_error }
+    it { expect{ get :index }.not_to raise_error }
+    it { expect{ get :new }.not_to raise_error }
+  end
+
+  context 'when not authorized' do
+    before do
+      allow(subject).to receive(:current_user) { OpenStruct.new(admin?: false) }
+    end
+
+    it { expect{ get :edit }.not_to raise_error }
+    it { expect{ get :index }.to raise_error{ ActionBouncer::Unauthorized } }
+    it { expect{ get :new }.to raise_error{ ActionBouncer::Unauthorized } }
+  end
+end
+


### PR DESCRIPTION
This PR introduces a new attribute `except` this might be used when you don't want validate one or more given actions 

Follow the example : 

``` ruby 
 allow :current_user,
   to: [:index, :new],
   except: :edit,
   if: :admin?
```

The action `:edit` should not be validated, that means it simply ignore the action for authorization purpose.